### PR TITLE
Feature/shell command vs ruby

### DIFF
--- a/recipes/jce.rb
+++ b/recipes/jce.rb
@@ -64,6 +64,6 @@ if node['java'].key? 'jdk_version'
     code <<-CODE
       find -name '*.jar' -exec cp '{}' #{jce_dir} \\;
     CODE
-    not_if { ::FileUtils.compare_file("#{jce_tmp}/jce/US_export_policy.jar", "#{jce_dir}/US_export_policy.jar") }
+    not_if "diff -q #{jce_tmp}/jce/US_export_policy.jar #{jce_dir}/US_export_policy.jar"
   end
 end


### PR DESCRIPTION
Use a shell command for bash resource guard, versus ruby, since chefspec cannot easily test for the ruby. Plus, I dislike mixing languages in a single resource.
