### PR TITLE
parsing correct field for db name

### DIFF
--- a/recipes/hive_metastore_db_init.rb
+++ b/recipes/hive_metastore_db_init.rb
@@ -26,7 +26,7 @@ if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.o
   jdo_array = node['hive']['hive_site']['javax.jdo.option.ConnectionURL'].split(':')
   hive_uris = node['hive']['hive_site']['hive.metastore.uris'].gsub('thrift://', '').gsub(':9083', '').split(',')
   db_type = jdo_array[1]
-  db_name = jdo_array[2].split('/').last.split('?').first
+  db_name = jdo_array[3].split('/').last.split('?').first
   db_user =
     if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.option.ConnectionUserName')
       node['hive']['hive_site']['javax.jdo.option.ConnectionUserName']


### PR DESCRIPTION
parsing the correct field for metastore db name:

``` ruby
1.9.3p374 :003 > db_name = jdo_array[2].split('/').last.split('?').first
 => "%host.service.mysql-server%" 
1.9.3p374 :004 > db_name3 = jdo_array[3].split('/').last.split('?').first
 => "hive" 
```
