### PR TITLE
Feature/yarn retry forever

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,7 +13,7 @@ default['hadoop']['mapred_site']['mapreduce.framework.name'] = 'yarn'
 # yarn-site.xml
 default['hadoop']['yarn_site']['yarn.log-aggregation-enable'] = 'true'
 default['hadoop']['yarn_site']['yarn.scheduler.minimum-allocation-mb'] = '512'
-default['hadoop']['yarn_site']['yarn.nodemanager.resourcemanager.connect.wait.secs'] '-1'
+default['hadoop']['yarn_site']['yarn.nodemanager.resourcemanager.connect.wait.secs'] = '-1'
 default['hadoop']['yarn_site']['yarn.nodemanager.vmem-check-enabled'] = 'false'
 default['hadoop']['yarn_site']['yarn.nodemanager.vmem-pmem-ratio'] = '5.1'
 default['hadoop']['yarn_site']['yarn.nodemanager.delete.debug-delay-sec'] = '86400'


### PR DESCRIPTION
This resolves an issue found by @haeley in clusters we create. If the RM goes down for more than 15 minutes, the NM give up trying to connect. This tells them to retry forever.
