### PR TITLE
Strip host/realm from kerberos principals for ZooKeeper

### DIFF
--- a/attributes/krb5.rb
+++ b/attributes/krb5.rb
@@ -117,5 +117,7 @@ if node['zookeeper'].key?('zoocfg') && node['zookeeper']['zoocfg'].key?('authPro
 
   # zoo.cfg
   default['zookeeper']['zoocfg']['jaasLoginRenew'] = '3600000' unless node['zookeeper']['zoocfg']['jaasLoginRenew']
+  default['zookeeper']['zoocfg']['kerberos.removeHostFromPrincipal'] = 'true'
+  default['zookeeper']['zoocfg']['kerberos.removeRealmFromPrincipal'] = 'true'
 
 end


### PR DESCRIPTION
Remove host/realm from principal... per @poornachandra and http://hbase.apache.org/book/zk.sasl.auth.html
