### PR TITLE
Remove JSVC settings and update Hadoop dependency to match

### DIFF
--- a/attributes/krb5.rb
+++ b/attributes/krb5.rb
@@ -34,12 +34,6 @@ if node['hadoop'].key?('core_site') && node['hadoop']['core_site'].key?('hadoop.
   default['hadoop']['container_executor']['yarn.nodemanager.container-executor.class'] = 'org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor'
 
   # hadoop-env.sh
-  default['hadoop']['hadoop_env']['jsvc_home'] =
-    if node['platform_family'] == 'debian'
-      '/usr/lib/bigtop-utils'
-    elsif node['platform_family'] == 'rhel'
-      '/usr/libexec/bigtop-utils'
-    end
   default['hadoop']['hadoop_env']['hadoop_secure_dn_user'] = 'hdfs'
   default['hadoop']['hadoop_env']['hadoop_secure_dn_pid_dir'] = '/var/run/hadoop-hdfs'
   default['hadoop']['hadoop_env']['hadoop_secure_dn_log_dir'] = '/var/log/hadoop-hdfs'

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ version '0.1.12'
   depends cb
 end
 
-depends 'hadoop', '>= 1.3.0'
+depends 'hadoop', '>= 1.9.1'
 depends 'mysql', '< 5.0.0'
 depends 'database', '< 2.1.0'
 depends 'krb5', '>= 1.0.0'


### PR DESCRIPTION
The main `caskdata/hadoop_cookbook` handles this. Remove it, so we don't stomp on that cookbook's work.
