### PR TITLE
Secure Hive setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gem 'foodcritic', '~> 3.0'
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
+gem 'chef', '< 12.0'
+
 gem 'rubocop'
 gem 'rubocop-checkstyle_formatter', require: false
 gem 'rainbow', '<= 1.99.1'

--- a/attributes/krb5.rb
+++ b/attributes/krb5.rb
@@ -53,6 +53,10 @@ if node['hadoop'].key?('core_site') && node['hadoop']['core_site'].key?('hadoop.
   default['hadoop']['hdfs_site']['dfs.datanode.address'] = '0.0.0.0:1004'
   default['hadoop']['hdfs_site']['dfs.datanode.http.address'] = '0.0.0.0:1006'
 
+  # mapred-site.xml
+  default['hadoop']['mapred_site']['mapreduce.jobhistory.keytab'] = "#{node['krb5_utils']['keytabs_dir']}/jhs.service.keytab"
+  default['hadoop']['mapred_site']['mapreduce.jobhistory.principal'] = "jhs/_HOST@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
+
   # yarn-site.xml
   default['hadoop']['yarn_site']['yarn.resourcemanager.keytab'] = "#{node['krb5_utils']['keytabs_dir']}/yarn.service.keytab"
   default['hadoop']['yarn_site']['yarn.nodemanager.keytab'] = "#{node['krb5_utils']['keytabs_dir']}/yarn.service.keytab"

--- a/recipes/kerberos_init.rb
+++ b/recipes/kerberos_init.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop_wrapper
 # Recipe:: kerberos_init
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -56,5 +56,13 @@ if node['hbase'].key?('hbase_site') && node['hbase']['hbase_site'].key?('hbase.s
 
   if secure_hadoop_enabled.nil?
     Chef::Application.fatal!('You must enable kerberos in Hadoop or disable kerberos for HBase!')
+  end
+end
+
+if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('hive.metastore.sasl.enabled') &&
+   node['hive']['hive_site']['hive.metastore.sasl.enabled'].to_s == 'true'
+
+  if secure_hadoop_enabled.nil?
+    Chef::Application.fatal!('You must enable kerberos in Hadoop or disable kerberos for Hive!')
   end
 end


### PR DESCRIPTION
Hive requires the Mapreduce Jobhistory Server, so we need to ensure that we setup the configuration for it.