### PR TITLE
Setup yarn.app.mapreduce.am.staging-dir

### DIFF
--- a/recipes/hadoop_yarn_resourcemanager_init.rb
+++ b/recipes/hadoop_yarn_resourcemanager_init.rb
@@ -34,3 +34,10 @@ ruby_block 'initaction-create-yarn-remote-app-log-dir' do
   end
   not_if "hdfs dfs -ls #{dfs}#{node['hadoop']['yarn_site']['yarn-remote-app-log-dir']}", :user => 'hdfs'
 end
+
+ruby_block 'initaction-create-yarn-app-mapreduce-am-staging-dir' do
+  block do
+    resources('execute[yarn-app-mapreduce-am-staging-dir]').run_action(:run)
+  end
+  not_if "hdfs dfs -ls #{dfs}#{node['hadoop']['mapred_site']['yarn.app.mapreduce.am.staging-dir']}", :user => 'hdfs'
+end


### PR DESCRIPTION
Runs the execute block in the `hadoop` cookbook.