### PR TITLE
dont try to create databases if derby is specified

### DIFF
--- a/recipes/hive_metastore_db_init.rb
+++ b/recipes/hive_metastore_db_init.rb
@@ -22,7 +22,9 @@ include_recipe 'hadoop::default'
 include_recipe 'hadoop::hive_metastore'
 
 # Set up our database
-if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.option.ConnectionURL')
+if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.option.ConnectionURL') &&
+   node['hive']['hive_site'].key?('javax.jdo.option.ConnectionDriverName') &&
+   node['hive']['hive_site']['javax.jdo.option.ConnectionDriverName'] != 'org.apache.derby.jdbc.EmbeddedDriver'
   jdo_array = node['hive']['hive_site']['javax.jdo.option.ConnectionURL'].split(':')
   hive_uris = node['hive']['hive_site']['hive.metastore.uris'].gsub('thrift://', '').gsub(':9083', '').split(',')
   hive_uris.push('localhost')


### PR DESCRIPTION
Ensure the ``javax.jdo.option.ConnectionDriverName`` attribute is not the derby default before trying to create databases.  The ensuing split logic causes a nilpointer on the default derby string.