### PR TITLE
IOP support

### DIFF
--- a/recipes/hadoop_yarn_resourcemanager_init.rb
+++ b/recipes/hadoop_yarn_resourcemanager_init.rb
@@ -46,3 +46,10 @@ ruby_block 'initaction-copy-hdp22-mapreduce-tarball' do
   end
   only_if { node['hadoop']['distribution'] == 'hdp' && node['hadoop']['distribution_version'].to_f >= 2.2 }
 end
+
+ruby_block 'initaction-copy-iop-mapreduce-tarball' do
+  block do
+    resources('execute[iop-mapreduce-tarball]').run_action(:run)
+  end
+  only_if { node['hadoop']['distribution'] == 'iop' }
+end


### PR DESCRIPTION
The only thing that's necessary here is to install the MapReduce framework into HDFS to support rolling upgrades. This requires caskdata/hadoop_cookbook#226 to function correctly.