### PR TITLE
Use Gem::Version for sorting by version

### DIFF
--- a/recipes/hive_metastore_db_init.rb
+++ b/recipes/hive_metastore_db_init.rb
@@ -69,7 +69,7 @@ if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.o
     mysql_database 'import-hive-schema' do
       connection mysql_connection_info
       database_name db_name
-      sql lazy { ::File.open(Dir.glob("#{sql_dir}/mysql/hive-schema-*").sort_by! { |s| Gem::Version.new(s.split('/').last.gsub('hive-schema-', '').gsub('.mysql.sql', ''))}.last).read }
+      sql lazy { ::File.open(Dir.glob("#{sql_dir}/mysql/hive-schema-*").sort_by! { |s| Gem::Version.new(s.split('/').last.gsub('hive-schema-', '').gsub('.mysql.sql', '')) }.last).read }
       action :query
     end
     hive_uris.each do |hive_host|

--- a/recipes/hive_metastore_db_init.rb
+++ b/recipes/hive_metastore_db_init.rb
@@ -69,7 +69,7 @@ if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.o
     mysql_database 'import-hive-schema' do
       connection mysql_connection_info
       database_name db_name
-      sql lazy { ::File.open(Dir.glob("#{sql_dir}/mysql/hive-schema-*").sort_by! { |s| s[/\d+/].to_i }.last).read }
+      sql lazy { ::File.open(Dir.glob("#{sql_dir}/mysql/hive-schema-*").sort_by! { |s| Gem::Version.new(s.split('/').last.gsub('hive-schema-', '').gsub('.mysql.sql', ''))}.last).read }
       action :query
     end
     hive_uris.each do |hive_host|


### PR DESCRIPTION
The previous sort was sorting by integer, which always matched the first `0`, giving essentially no sort.

Before:
```
irb(main):001:0> sql_dir = '/usr/hdp/2.3.2.0-2950/hive/scripts/metastore/upgrade'
=> "/usr/hdp/2.3.2.0-2950/hive/scripts/metastore/upgrade"
irb(main):002:0> ::File.open(Dir.glob("#{sql_dir}/mysql/hive-schema-*").sort_by! { |s| s[/\d+/].to_i }.last)
=> #<File:/usr/hdp/2.3.2.0-2950/hive/scripts/metastore/upgrade/mysql/hive-schema-0.4.1.mysql.sql>
```

After:
```
irb(main):003:0> ::File.open(Dir.glob("#{sql_dir}/mysql/hive-schema-*").sort_by! { |s| Gem::Version.new(s.split('/').last.gsub('hive-schema-', '').gsub('.mysql.sql', ''))}.last)
=> #<File:/usr/hdp/2.3.2.0-2950/hive/scripts/metastore/upgrade/mysql/hive-schema-1.2.0.mysql.sql>
```