### PR TITLE
Ensure spark user exists before writing keytabs

### DIFF
--- a/recipes/kerberos_init.rb
+++ b/recipes/kerberos_init.rb
@@ -28,7 +28,7 @@ if node['hadoop'].key?('core_site') && node['hadoop']['core_site'].key?('hadoop.
   secure_hadoop_enabled = true
 
   # Create users for services not in base Hadoop
-  %w(hbase hive zookeeper).each do |u|
+  %w(hbase hive spark zookeeper).each do |u|
     user u do
       action :create
     end


### PR DESCRIPTION
Otherwise, we try to write a file owned by a non-existent user.