### PR TITLE
COOK-106 Use split client_jaas and master_jaas configs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,16 +11,17 @@ if RUBY_VERSION.to_f < 2.0
   gem 'varia_model', '< 0.5.0'
   gem 'fauxhai', '< 3.5.0'
   gem 'json', '< 2.0'
+  gem 'rubocop', '< 0.42'
 else
   gem 'chef', '< 12.5' # Testing
+  gem 'rubocop'
 end
 
 gem 'chef-zero', '< 4.6' if RUBY_VERSION.to_f < 2.1
+gem 'ffi-yajl', '< 2.3' if RUBY_VERSION.to_f < 2.1
 gem 'rack', '< 2.0' if RUBY_VERSION.to_f < 2.2
 gem 'ridley', '~> 4.2.0'
 gem 'faraday', '< 0.9.2'
-gem 'rubocop'
-gem 'rubocop-checkstyle_formatter', require: false
 gem 'rainbow', '<= 1.99.1'
 
 group :integration do


### PR DESCRIPTION
This sets the keytabs in `master_jaas.conf` for HBase/ZooKeeper, but not `client_jaas.conf` for each. This way the ZooKeeper connections are authenticated as the correct client when using client tools.