### PR TITLE
Remove kerberos_init recipe from default

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop_wrapper
 # Recipe:: default
 #
-# Copyright © 2013 Cask Data, Inc.
+# Copyright © 2013-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,4 +35,3 @@ if node.key?('java') && node['java'].key?('java_home')
 end
 
 include_recipe 'hadoop::default'
-include_recipe 'hadoop_wrapper::kerberos_init'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -11,8 +11,8 @@ describe 'hadoop_wrapper::default' do
       end.converge(described_recipe)
     end
 
-    it 'includes kerberos_init recipe' do
-      expect(chef_run).to include_recipe('hadoop_wrapper::kerberos_init')
+    it 'includes java recipe' do
+      expect(chef_run).to include_recipe('java::default')
     end
   end
 end


### PR DESCRIPTION
This forces a user to manually add the `kerberos_init` recipe into their run_list in a location of their choosing.