### PR TITLE
Version bump to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ There are no attributes specific to this cookbook, however we set many default a
 Include the relevant recipes in your run-list.
 
 
-
+NOTE: Starting with version `1.0.0`, the `kerberos_init` recipe is no longer run unconditionally.

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Hadoop wrapper'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.5.1'
+version '1.0.0'
 
 %w(apt krb5_utils yum).each do |cb|
   depends cb


### PR DESCRIPTION
This version bumps to 1.0.0 and adds a note to the README. This cookbook isn't published to Chef Supermarket, so I think this warning and version bump is sufficient.