### PR TITLE
Bring back hadoop

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Hadoop wrapper'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.0.0'
+version '2.0.1'
 
 %w(apt krb5_utils yum).each do |cb|
   depends cb

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,4 +34,5 @@ if node.key?('java') && node['java'].key?('java_home')
   node.default['hive']['hive_env']['java_home'] = node['java']['java_home']
 end
 
+include_recipe 'hadoop::default'
 include_recipe 'hadoop_wrapper::kerberos_init'

--- a/recipes/kerberos_init.rb
+++ b/recipes/kerberos_init.rb
@@ -27,8 +27,8 @@ if node['hadoop'].key?('core_site') && node['hadoop']['core_site'].key?('hadoop.
   Chef::Log.info("Secure Hadoop Enabled: Kerberos Realm '#{node['krb5']['krb5_conf']['realms']['default_realm']}'")
   secure_hadoop_enabled = true
 
-  # Create users for services
-  %w(hadoop hbase hdfs hive mapred spark yarn zookeeper).each do |u|
+  # Create users for services not in hadoop::default
+  %w(hbase hive spark zookeeper).each do |u|
     user u do
       action :create
     end

--- a/spec/kerberos_init_spec.rb
+++ b/spec/kerberos_init_spec.rb
@@ -13,7 +13,7 @@ describe 'hadoop_wrapper::kerberos_init' do
         %w(HTTP hdfs hbase hive jhs mapred spark yarn zookeeper).each do |kt|
           stub_command("test -e /etc/security/keytabs/#{kt}.service.keytab").and_return(true)
         end
-        stub_command(/kadmin -w password -q 'list_principals' | grep -v Auth/).and_return(true)
+        stub_command(/kadmin -w password -q/).and_return(true)
         stub_command('test -e /etc/security/keytabs/yarn.keytab').and_return(true)
         #
         stub_command('test -e /etc/default/hadoop-hdfs-datanode').and_return(true)


### PR DESCRIPTION
Unfortunately, the previous changes caused the cookbook to be dependent on ordering to run correctly. For example, if `hadoop::default` came before this cookbook in a run_list, the `hadoop` group would already exist, causing this cookbook to fail.