### PR TITLE
COOK-109 Use execute to load SQL files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ if RUBY_VERSION.to_f < 2.1
   gem 'fauxhai', '< 3.5'
   gem 'ffi-yajl', '< 2.3'
   gem 'dep_selector', '< 1.0.4'
+  gem 'net-http-persistent', '< 3.0'
 end
 
 if RUBY_VERSION.to_f < 2.0

--- a/recipes/hive_metastore_db_init.rb
+++ b/recipes/hive_metastore_db_init.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop_wrapper
 # Recipe:: hive_metastore_db_init
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,11 +66,14 @@ if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.o
       privileges [:all]
       action :grant
     end
-    mysql_database 'import-hive-schema' do
-      connection mysql_connection_info
-      database_name db_name
-      sql lazy { ::File.open(Dir.glob("#{sql_dir}/mysql/hive-schema-*").sort_by! { |s| Gem::Version.new(s.split('/').last.gsub('hive-schema-', '').gsub('.mysql.sql', '')) }.last).read }
-      action :query
+    execute 'mysql-import-hive-schema' do
+      command <<-EOF
+        mysql --batch -D#{db_name} -p#{node['mysql']['server_root_password']} < $(ls -1 hive-schema-* | sort -n | tail -n 1)
+        EOF
+      sensitive true # keep password hidden
+      user 'root'
+      action :run
+      cwd "#{sql_dir}/mysql"
     end
     hive_uris.each do |hive_host|
       mysql_database_user "#{db_user}-#{hive_host}" do
@@ -101,11 +104,15 @@ if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.o
       password db_pass
       action :create
     end
-    postgresql_database 'import-hive-schema' do
-      connection postgresql_connection_info
-      database_name db_name
-      sql lazy { ::File.open(Dir.glob("#{sql_dir}/postgres/hive-schema-*").sort_by! { |s| s[/\d+/].to_i }.last).read }
-      action :query
+    execute 'postgresql-import-hive-schema' do
+      command <<-EOF
+        psql #{db_name} < $(ls -1 hive-schema-* | sort -n | tail -n 1)
+        EOF
+      sensitive true # keep password hidden
+      user 'postgres'
+      action :run
+      cwd "#{sql_dir}/postgres"
+      environment('PGPASSWORD' => node['postgresql']['password']['postgres'])
     end
     hive_uris.each do |hive_host|
       postgresql_database_user "#{db_user}-#{hive_host}" do

--- a/recipes/hive_metastore_db_init.rb
+++ b/recipes/hive_metastore_db_init.rb
@@ -66,14 +66,15 @@ if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.o
       privileges [:all]
       action :grant
     end
-    execute 'mysql-import-hive-schema' do
+    execute 'mysql-import-hive-schema' do # ~FC009
       command <<-EOF
-        mysql --batch -D#{db_name} -p#{node['mysql']['server_root_password']} < $(ls -1 hive-schema-* | sort -n | tail -n 1)
+        mysql --batch -D#{db_name} < $(ls -1 hive-schema-* | sort -n | tail -n 1)
         EOF
-      sensitive true # keep password hidden
+      sensitive true
       user 'root'
       action :run
       cwd "#{sql_dir}/mysql"
+      environment('MYSQL_PWD' => node['mysql']['server_root_password'])
     end
     hive_uris.each do |hive_host|
       mysql_database_user "#{db_user}-#{hive_host}" do
@@ -104,11 +105,11 @@ if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.o
       password db_pass
       action :create
     end
-    execute 'postgresql-import-hive-schema' do
+    execute 'postgresql-import-hive-schema' do # ~FC009
       command <<-EOF
         psql #{db_name} < $(ls -1 hive-schema-* | sort -n | tail -n 1)
         EOF
-      sensitive true # keep password hidden
+      sensitive true
       user 'postgres'
       action :run
       cwd "#{sql_dir}/postgres"

--- a/spec/hive_metastore_db_init_spec.rb
+++ b/spec/hive_metastore_db_init_spec.rb
@@ -16,9 +16,5 @@ describe 'hadoop_wrapper::hive_metastore_db_init' do
         stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)
     end
-
-    it 'runs execute[mysql-import-hive-schema] block' do
-      expect(chef_run).to run_execute('mysql-import-hive-schema')
-    end
   end
 end

--- a/spec/hive_metastore_db_init_spec.rb
+++ b/spec/hive_metastore_db_init_spec.rb
@@ -13,6 +13,7 @@ describe 'hadoop_wrapper::hive_metastore_db_init' do
         stub_command(%r{test -e /tmp/jce(.+)/}).and_return(false)
         stub_command(%r{diff -q /tmp/jce(.+)/}).and_return(false)
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)
+        stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)
     end
 

--- a/spec/hive_metastore_db_init_spec.rb
+++ b/spec/hive_metastore_db_init_spec.rb
@@ -15,5 +15,9 @@ describe 'hadoop_wrapper::hive_metastore_db_init' do
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)
       end.converge(described_recipe)
     end
+
+    it 'runs execute[mysql-import-hive-schema] block' do
+      expect(chef_run).to run_execute('mysql-import-hive-schema')
+    end
   end
 end

--- a/spec/hive_metastore_db_init_spec.rb
+++ b/spec/hive_metastore_db_init_spec.rb
@@ -6,8 +6,8 @@ describe 'hadoop_wrapper::hive_metastore_db_init' do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
         node.automatic['memory']['total'] = '4099400kB'
-        node.default['hive']['hive_site']['hive.metastore.uris'] = 'thrift://fauxhai.local:9083'
-        node.default['hive']['hive_site']['javax.jdo.option.ConnectionURL'] = 'jdbc:mysql://localhost:3306/hive'
+        node.override['hive']['hive_site']['hive.metastore.uris'] = 'thrift://fauxhai.local:9083'
+        node.override['hive']['hive_site']['javax.jdo.option.ConnectionURL'] = 'jdbc:mysql://localhost:3306/hive'
         stub_command(/update-alternatives --display (.+) /).and_return(false)
         stub_command(/jce(.+).zip' | sha256sum/).and_return(false)
         stub_command(%r{test -e /tmp/jce(.+)/}).and_return(false)


### PR DESCRIPTION
This replaces the `mysql_database` and `postgresql_database` query actions with execute resources, since the SQL files include other SQL files and the `database` cookbook's providers don't support using SQL files directly, and the files include a second SQL file.