### PR TITLE
Use new krb5_principal and krb5_keytab LWRPs

### DIFF
--- a/attributes/krb5.rb
+++ b/attributes/krb5.rb
@@ -27,17 +27,6 @@ if node['hadoop'].key?('core_site') && node['hadoop']['core_site'].key?('hadoop.
    node['hadoop']['core_site']['hadoop.security.authentication'] == 'kerberos'
 
   include_attribute 'krb5'
-  include_attribute 'krb5_utils'
-
-  # Create service keytabs for all services, since we may be a client
-  default['krb5_utils']['krb5_service_keytabs']['HTTP'] = { 'owner' => 'hdfs', 'group' => 'hadoop', 'mode' => '0640' }
-  default['krb5_utils']['krb5_service_keytabs']['hdfs'] = { 'owner' => 'hdfs', 'group' => 'hadoop', 'mode' => '0640' }
-  default['krb5_utils']['krb5_service_keytabs']['hbase'] = { 'owner' => 'hbase', 'group' => 'hadoop', 'mode' => '0640' }
-  default['krb5_utils']['krb5_service_keytabs']['hive'] = { 'owner' => 'hive', 'group' => 'hadoop', 'mode' => '0640' }
-  default['krb5_utils']['krb5_service_keytabs']['mapred'] = { 'owner' => 'mapred', 'group' => 'hadoop', 'mode' => '0640' }
-  default['krb5_utils']['krb5_service_keytabs']['spark'] = { 'owner' => 'spark', 'group' => 'hadoop', 'mode' => '0640' }
-  default['krb5_utils']['krb5_service_keytabs']['yarn'] = { 'owner' => 'yarn', 'group' => 'hadoop', 'mode' => '0640' }
-  default['krb5_utils']['krb5_service_keytabs']['zookeeper'] = { 'owner' => 'zookeeper', 'group' => 'hadoop', 'mode' => '0640' }
 
   # Hadoop
 
@@ -79,19 +68,19 @@ if node['hadoop'].key?('core_site') && node['hadoop']['core_site'].key?('hadoop.
   default['hadoop']['hdfs_site']['dfs.web.authentication.kerberos.principal'] = "HTTP/_HOST@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
   default['hadoop']['hdfs_site']['dfs.namenode.kerberos.internal.spnego.principal'] = "HTTP/_HOST@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
   default['hadoop']['hdfs_site']['dfs.secondary.namenode.kerberos.internal.spnego.principal'] = "HTTP/_HOST@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
-  default['hadoop']['hdfs_site']['dfs.datanode.keytab.file'] = "#{node['krb5_utils']['keytabs_dir']}/hdfs.service.keytab"
-  default['hadoop']['hdfs_site']['dfs.namenode.keytab.file'] = "#{node['krb5_utils']['keytabs_dir']}/hdfs.service.keytab"
-  default['hadoop']['hdfs_site']['dfs.secondary.namenode.keytab.file'] = "#{node['krb5_utils']['keytabs_dir']}/hdfs.service.keytab"
+  default['hadoop']['hdfs_site']['dfs.datanode.keytab.file'] = "#{node['krb5']['keytabs_dir']}/hdfs.service.keytab"
+  default['hadoop']['hdfs_site']['dfs.namenode.keytab.file'] = "#{node['krb5']['keytabs_dir']}/hdfs.service.keytab"
+  default['hadoop']['hdfs_site']['dfs.secondary.namenode.keytab.file'] = "#{node['krb5']['keytabs_dir']}/hdfs.service.keytab"
   default['hadoop']['hdfs_site']['dfs.datanode.address'] = '0.0.0.0:1004'
   default['hadoop']['hdfs_site']['dfs.datanode.http.address'] = '0.0.0.0:1006'
 
   # mapred-site.xml
-  default['hadoop']['mapred_site']['mapreduce.jobhistory.keytab'] = "#{node['krb5_utils']['keytabs_dir']}/mapred.service.keytab"
+  default['hadoop']['mapred_site']['mapreduce.jobhistory.keytab'] = "#{node['krb5']['keytabs_dir']}/mapred.service.keytab"
   default['hadoop']['mapred_site']['mapreduce.jobhistory.principal'] = "mapred/_HOST@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
 
   # yarn-site.xml
-  default['hadoop']['yarn_site']['yarn.resourcemanager.keytab'] = "#{node['krb5_utils']['keytabs_dir']}/yarn.service.keytab"
-  default['hadoop']['yarn_site']['yarn.nodemanager.keytab'] = "#{node['krb5_utils']['keytabs_dir']}/yarn.service.keytab"
+  default['hadoop']['yarn_site']['yarn.resourcemanager.keytab'] = "#{node['krb5']['keytabs_dir']}/yarn.service.keytab"
+  default['hadoop']['yarn_site']['yarn.nodemanager.keytab'] = "#{node['krb5']['keytabs_dir']}/yarn.service.keytab"
   default['hadoop']['yarn_site']['yarn.resourcemanager.principal'] = "yarn/_HOST@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
   default['hadoop']['yarn_site']['yarn.nodemanager.principal'] = "yarn/_HOST@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
   default['hadoop']['yarn_site']['yarn.nodemanager.linux-container-executor.group'] = 'yarn'
@@ -102,8 +91,8 @@ if node['hadoop'].key?('core_site') && node['hadoop']['core_site'].key?('hadoop.
   # hbase-site.xml
   default['hbase']['hbase_site']['hbase.security.authorization'] = 'true'
   default['hbase']['hbase_site']['hbase.security.authentication'] = 'kerberos'
-  default['hbase']['hbase_site']['hbase.master.keytab.file'] = "#{node['krb5_utils']['keytabs_dir']}/hbase.service.keytab"
-  default['hbase']['hbase_site']['hbase.regionserver.keytab.file'] = "#{node['krb5_utils']['keytabs_dir']}/hbase.service.keytab"
+  default['hbase']['hbase_site']['hbase.master.keytab.file'] = "#{node['krb5']['keytabs_dir']}/hbase.service.keytab"
+  default['hbase']['hbase_site']['hbase.regionserver.keytab.file'] = "#{node['krb5']['keytabs_dir']}/hbase.service.keytab"
   default['hbase']['hbase_site']['hbase.master.kerberos.principal'] = "hbase/_HOST@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
   default['hbase']['hbase_site']['hbase.regionserver.kerberos.principal'] = "hbase/_HOST@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
   default['hbase']['hbase_site']['hbase.coprocessor.region.classes'] = 'org.apache.hadoop.hbase.security.token.TokenProvider,org.apache.hadoop.hbase.security.access.SecureBulkLoadEndpoint,org.apache.hadoop.hbase.security.access.AccessController'
@@ -114,10 +103,10 @@ if node['hadoop'].key?('core_site') && node['hadoop']['core_site'].key?('hadoop.
 
   # hive-site.xml
   default['hive']['hive_site']['hive.metastore.sasl.enabled'] = 'true'
-  default['hive']['hive_site']['hive.metastore.kerberos.keytab.file'] = "#{node['krb5_utils']['keytabs_dir']}/hive.service.keytab"
+  default['hive']['hive_site']['hive.metastore.kerberos.keytab.file'] = "#{node['krb5']['keytabs_dir']}/hive.service.keytab"
   default['hive']['hive_site']['hive.metastore.kerberos.principal'] = "hive/_HOST@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
   default['hive']['hive_site']['hive.server2.authentication'] = 'KERBEROS'
-  default['hive']['hive_site']['hive.server2.authentication.kerberos.keytab'] = "#{node['krb5_utils']['keytabs_dir']}/hive.service.keytab"
+  default['hive']['hive_site']['hive.server2.authentication.kerberos.keytab'] = "#{node['krb5']['keytabs_dir']}/hive.service.keytab"
   default['hive']['hive_site']['hive.server2.authentication.kerberos.principal'] = "hive/_HOST@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
 
   # Spark
@@ -126,7 +115,7 @@ if node['hadoop'].key?('core_site') && node['hadoop']['core_site'].key?('hadoop.
   default['spark']['spark_defaults']['spark.history.kerberos.enabled'] = 'true'
   # We cannot use _HOST here... https://issues.apache.org/jira/browse/SPARK-17121
   default['spark']['spark_defaults']['spark.history.kerberos.principal'] = "spark/#{node['fqdn']}@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
-  default['spark']['spark_defaults']['spark.history.kerberos.keytab'] = "#{node['krb5_utils']['keytabs_dir']}/spark.service.keytab"
+  default['spark']['spark_defaults']['spark.history.kerberos.keytab'] = "#{node['krb5']['keytabs_dir']}/spark.service.keytab"
 
   # ZooKeeper
 
@@ -135,7 +124,7 @@ if node['hadoop'].key?('core_site') && node['hadoop']['core_site'].key?('hadoop.
     default[svc]['master_jaas']['client']['usekeytab'] = 'true'
     # We cannot use _HOST here... https://issues.apache.org/jira/browse/ZOOKEEPER-1422
     default[svc]['master_jaas']['client']['principal'] = "#{svc}/#{node['fqdn']}@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
-    default[svc]['master_jaas']['client']['keytab'] = "#{node['krb5_utils']['keytabs_dir']}/#{svc}.service.keytab"
+    default[svc]['master_jaas']['client']['keytab'] = "#{node['krb5']['keytabs_dir']}/#{svc}.service.keytab"
     default[svc]['client_jaas']['client']['usekeytab'] = 'false'
   end
   jsalc = '-Djava.security.auth.login.config'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Hadoop wrapper'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.1.0'
 
-%w(apt krb5_utils yum).each do |cb|
+%w(apt yum).each do |cb|
   depends cb
 end
 
@@ -14,7 +14,7 @@ depends 'java', '~> 1.40'
 depends 'hadoop', '>= 2.0.0'
 depends 'mysql', '< 5.0.0'
 depends 'database', '< 2.1.0'
-depends 'krb5', '>= 1.0.0'
+depends 'krb5', '>= 2.2.0'
 
 source_url 'https://github.com/caskdata/hadoop_wrapper_cookbook' if respond_to?(:source_url)
 issues_url 'https://issues.cask.co/browse/COOK/component/10601' if respond_to?(:issues_url)

--- a/recipes/kerberos_init.rb
+++ b/recipes/kerberos_init.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop_wrapper
 # Recipe:: kerberos_init
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,38 @@ if hadoop_kerberos?
     end
   end
 
-  include_recipe 'krb5_utils'
+  include_recipe 'krb5::rkerberos_gem'
+
+  # The HTTP principal is needed in multiple keytabs, so we define it separately
+  krb5_principal "HTTP/#{node['fqdn']}" do
+    randkey true
+    action :create
+  end
+
+  # Create service keytabs for all services, since we may be a client
+  keytabs = {
+    'hdfs'      => { 'owner' => 'hdfs', 'group' => 'hadoop', 'mode' => '0640' },
+    'hbase'     => { 'owner' => 'hbase', 'group' => 'hadoop', 'mode' => '0640' },
+    'hive'      => { 'owner' => 'hive', 'group' => 'hadoop', 'mode' => '0640' },
+    'jhs'       => { 'owner' => 'mapred', 'group' => 'hadoop', 'mode' => '0640' },
+    'mapred'    => { 'owner' => 'mapred', 'group' => 'hadoop', 'mode' => '0640' },
+    'spark'     => { 'owner' => 'spark', 'group' => 'hadoop', 'mode' => '0640' },
+    'yarn'      => { 'owner' => 'yarn', 'group' => 'hadoop', 'mode' => '0640' },
+    'zookeeper' => { 'owner' => 'zookeeper', 'group' => 'hadoop', 'mode' => '0640' }
+  }
+  keytabs.each do |name, opts|
+    krb5_principal "#{name}/#{node['fqdn']}" do
+      randkey true
+      action :create
+    end
+    krb5_keytab "#{node['krb5']['keytabs_dir']}/#{name}.service.keytab" do
+      principals ["#{name}/#{node['fqdn']}", "HTTP/#{node['fqdn']}"]
+      owner opts['owner']
+      group opts['group']
+      mode  opts['mode']
+    end
+  end
+
   # Hack up /etc/default/hadoop-hdfs-datanode
   execute 'modify-etc-default-files' do
     command 'sed -i -e "/HADOOP_SECURE_DN/ s/^#//g" /etc/default/hadoop-hdfs-datanode'
@@ -37,10 +68,10 @@ if hadoop_kerberos?
   end
   # We need to kinit as hdfs to create directories
   execute 'kinit-as-hdfs-user' do
-    command "kinit -kt #{node['krb5_utils']['keytabs_dir']}/hdfs.service.keytab hdfs/#{node['fqdn']}@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
+    command "kinit -kt #{node['krb5']['keytabs_dir']}/hdfs.service.keytab hdfs/#{node['fqdn']}@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
     user 'hdfs'
     group 'hdfs'
-    only_if "test -e #{node['krb5_utils']['keytabs_dir']}/hdfs.service.keytab"
+    only_if "test -e #{node['krb5']['keytabs_dir']}/hdfs.service.keytab"
   end
 end
 

--- a/spec/hadoop_hdfs_namenode_init_spec.rb
+++ b/spec/hadoop_hdfs_namenode_init_spec.rb
@@ -7,9 +7,6 @@ describe 'hadoop_wrapper::hadoop_hdfs_namenode_init' do
         node.automatic['domain'] = 'example.com'
         node.automatic['memory']['total'] = '4099400kB'
         stub_command(/update-alternatives --display (.+) /).and_return(false)
-        stub_command(/jce(.+).zip' | sha256sum/).and_return(false)
-        stub_command(%r{test -e /tmp/jce(.+)/}).and_return(false)
-        stub_command(%r{diff -q /tmp/jce(.+)/}).and_return(false)
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)
         stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)

--- a/spec/hadoop_yarn_resourcemanager_init_spec.rb
+++ b/spec/hadoop_yarn_resourcemanager_init_spec.rb
@@ -11,9 +11,6 @@ describe 'hadoop_wrapper::hadoop_yarn_resourcemanager_init' do
         node.override['hadoop']['distribution_version'] = '2.2.4.2'
         stub_command(/hdfs dfs -/).and_return(false)
         stub_command(/update-alternatives --display (.+) /).and_return(false)
-        stub_command(/jce(.+).zip' | sha256sum/).and_return(false)
-        stub_command(%r{test -e /tmp/jce(.+)/}).and_return(false)
-        stub_command(%r{diff -q /tmp/jce(.+)/}).and_return(false)
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)
         stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)

--- a/spec/hbase_master_init_spec.rb
+++ b/spec/hbase_master_init_spec.rb
@@ -10,9 +10,6 @@ describe 'hadoop_wrapper::hbase_master_init' do
         node.default['hbase']['hbase_site']['hbase.zookeeper.quorum'] = 'fauxhai.local'
         stub_command(/hdfs dfs -/).and_return(false)
         stub_command(/update-alternatives --display (.+) /).and_return(false)
-        stub_command(/jce(.+).zip' | sha256sum/).and_return(false)
-        stub_command(%r{test -e /tmp/jce(.+)/}).and_return(false)
-        stub_command(%r{diff -q /tmp/jce(.+)/}).and_return(false)
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)
         stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)

--- a/spec/hive_init_spec.rb
+++ b/spec/hive_init_spec.rb
@@ -9,9 +9,6 @@ describe 'hadoop_wrapper::hive_init' do
         stub_command(/hdfs dfs -/).and_return(false)
         stub_command(/test -L/).and_return(false)
         stub_command(/update-alternatives --display (.+) /).and_return(false)
-        stub_command(/jce(.+).zip' | sha256sum/).and_return(false)
-        stub_command(%r{test -e /tmp/jce(.+)/}).and_return(false)
-        stub_command(%r{diff -q /tmp/jce(.+)/}).and_return(false)
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)
       end.converge(described_recipe)
     end

--- a/spec/hive_metastore_db_init_spec.rb
+++ b/spec/hive_metastore_db_init_spec.rb
@@ -9,9 +9,6 @@ describe 'hadoop_wrapper::hive_metastore_db_init' do
         node.override['hive']['hive_site']['hive.metastore.uris'] = 'thrift://fauxhai.local:9083'
         node.override['hive']['hive_site']['javax.jdo.option.ConnectionURL'] = 'jdbc:mysql://localhost:3306/hive'
         stub_command(/update-alternatives --display (.+) /).and_return(false)
-        stub_command(/jce(.+).zip' | sha256sum/).and_return(false)
-        stub_command(%r{test -e /tmp/jce(.+)/}).and_return(false)
-        stub_command(%r{diff -q /tmp/jce(.+)/}).and_return(false)
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)
         stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)

--- a/spec/hive_metastore_init_spec.rb
+++ b/spec/hive_metastore_init_spec.rb
@@ -9,9 +9,6 @@ describe 'hadoop_wrapper::hive_metastore_init' do
         stub_command(/hdfs dfs -/).and_return(false)
         stub_command(/test -L/).and_return(false)
         stub_command(/update-alternatives --display (.+) /).and_return(false)
-        stub_command(/jce(.+).zip' | sha256sum/).and_return(false)
-        stub_command(%r{test -e /tmp/jce(.+)/}).and_return(false)
-        stub_command(%r{diff -q /tmp/jce(.+)/}).and_return(false)
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)
       end.converge(described_recipe)
     end


### PR DESCRIPTION
- Replace all instances of krb5_utils with the LWRPs
- Create HTTP principal independent of others
- Add HTTP principal to service keytabs, only
- Update version dependencies on krb5 cookbook
