### PR TITLE
grant db permissions to metastore uri IPs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,18 @@ gem 'berkshelf', '~> 3.0'
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
+if RUBY_VERSION.to_f < 2.2
+  gem 'rack', '< 2.0'
+  if RUBY_VERSION.to_f < 2.1
+    gem 'fauxhai', '< 3.5'
+  else
+    gem 'fauxhai', '< 3.10'
+  end
+end
+
 if RUBY_VERSION.to_f < 2.1
   gem 'buff-ignore', '< 1.2'
   gem 'chef-zero', '< 4.6'
-  gem 'fauxhai', '< 3.5'
   gem 'ffi-yajl', '< 2.3'
   gem 'dep_selector', '< 1.0.4'
   gem 'net-http-persistent', '< 3.0'
@@ -26,7 +34,6 @@ else
   gem 'rubocop'
 end
 
-gem 'rack', '< 2.0' if RUBY_VERSION.to_f < 2.2
 gem 'ridley', '~> 4.2.0'
 gem 'faraday', '< 0.9.2'
 gem 'rainbow', '<= 1.99.1'


### PR DESCRIPTION
This explicitly grants db permissions to the resolved IPs for hive metastore host.  This works around a problem where the mysql permissions were not sufficient when the hostname resembles an IP (ie GCE DNS).