### PR TITLE
Version bump to 2.2.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,11 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Hadoop wrapper'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.1.0'
-
-%w(apt yum).each do |cb|
-  depends cb
-end
+version          '2.2.0'
 
 depends 'java', '~> 1.40'
 depends 'hadoop', '>= 2.0.0'


### PR DESCRIPTION
Includes:

- Use hadoop_kerberos? helper #76 
- Use new krb5_principal and krb5_keytab LWRPs #78 
- Grant DB permissions to metastore uri IPs #79 
- Update testing framework #80 
- COOK-119 Replace _HOST w/ FQDN for Spark HistoryServer #81 

Also, removing dependencies on `apt` and `yum` since neither was used in any current recipes.