### PR TITLE
update mysql dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Additional information can be found in the
 * java -> 1.40 (JCE needed for Kerberos)
 * hadoop >= 2.0
 * krb5 >= 2.2
-* mysql < 5.0 (Used by Hive Metastore)
-* database < 2.1
+* mysql ~> 8.0 (Used by Hive Metastore)
+* database ~> 6.0 
 
 # Attributes
 
@@ -45,6 +45,9 @@ There are no attributes specific to this cookbook, however we set many default
 attributes for the underlying cookbooks in order to have a reasonably
 configured Hadoop cluster. Be sure to look at the attributes files and
 override as desired.
+
+Note: in order to initialize the Hive Metastore database, root credentials must be
+supplied.  Currently, this must be set in `node['mysql']['server_root_password']`
 
 # Usage
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,13 +4,14 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Hadoop wrapper'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.2.0'
+version          '3.0.0'
 
 depends 'java', '~> 1.40'
 depends 'hadoop', '>= 2.0.0'
-depends 'mysql', '< 5.0.0'
-depends 'database', '< 2.1.0'
+depends 'mysql', '~> 8.0'
+depends 'database', '~> 6.0'
 depends 'krb5', '>= 2.2.0'
+depends 'mysql2_chef_gem'
 
 source_url 'https://github.com/caskdata/hadoop_wrapper_cookbook' if respond_to?(:source_url)
 issues_url 'https://issues.cask.co/browse/COOK/component/10601' if respond_to?(:issues_url)

--- a/recipes/hive_metastore_db_init.rb
+++ b/recipes/hive_metastore_db_init.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop_wrapper
 # Recipe:: hive_metastore_db_init
 #
-# Copyright © 2014-2016 Cask Data, Inc.
+# Copyright © 2014-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -52,7 +52,6 @@ if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.o
 
   case db_type
   when 'mysql'
-
     # Install dependency gem for the database cookbook LWRPs below
     mysql2_chef_gem 'default' do
       action :install
@@ -94,9 +93,8 @@ if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.o
       action :grant
     end
 
-    #mysql --batch -D#{db_name} -h 127.0.0.1 --socket /var/run/mysql-#{db_svcname}/mysqld.sock < $(ls -1 hive-schema-* | sort -n | tail -n 1)
-
     # import hive SQL via execute resource
+    # connect via 127.0.0.1 instead of localhost to avoid using an incorrect (default) socket file
     execute 'mysql-import-hive-schema' do # ~FC009
       command <<-EOF
         mysql --batch -D#{db_name} -h 127.0.0.1 < $(ls -1 hive-schema-* | sort -n | tail -n 1)

--- a/recipes/hive_metastore_db_init.rb
+++ b/recipes/hive_metastore_db_init.rb
@@ -52,21 +52,38 @@ if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.o
 
   case db_type
   when 'mysql'
-    include_recipe 'database::mysql'
+
+    # Install dependency gem for the database cookbook LWRPs below
+    mysql2_chef_gem 'default' do
+      action :install
+    end
+
+    # Install mysql client libraries via the mysql cookbook LWRP
+    mysql_client 'default' do
+      action :create
+    end
+
+    # Mysql root credentials for LWRPs to create additional users/databases
     mysql_connection_info = {
-      host: 'localhost',
+      host: '127.0.0.1', # if localhost is used, the named socket must also be specified
       username: 'root',
-      password: node['mysql']['server_root_password']
+      password: node['mysql']['server_root_password'] # this must be explicitly set
     }
+
+    # database cookbook LWRP to create a named database in "remote" instance
     mysql_database db_name do
       connection mysql_connection_info
       action :create
     end
+
+    # database cookbook LWRP to create a user in "remote" instance
     mysql_database_user db_user do
       connection mysql_connection_info
       password db_pass
       action :create
     end
+
+    # database cookbook LWRP to create a user in "remote" instance
     mysql_database_user "#{db_user}-localhost" do
       connection mysql_connection_info
       username db_user
@@ -76,9 +93,13 @@ if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.o
       privileges [:all]
       action :grant
     end
+
+    #mysql --batch -D#{db_name} -h 127.0.0.1 --socket /var/run/mysql-#{db_svcname}/mysqld.sock < $(ls -1 hive-schema-* | sort -n | tail -n 1)
+
+    # import hive SQL via execute resource
     execute 'mysql-import-hive-schema' do # ~FC009
       command <<-EOF
-        mysql --batch -D#{db_name} < $(ls -1 hive-schema-* | sort -n | tail -n 1)
+        mysql --batch -D#{db_name} -h 127.0.0.1 < $(ls -1 hive-schema-* | sort -n | tail -n 1)
         EOF
       sensitive true
       user 'root'
@@ -86,7 +107,9 @@ if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.o
       cwd "#{sql_dir}/mysql"
       environment('MYSQL_PWD' => node['mysql']['server_root_password'])
     end
+
     hive_uris.each do |hive_host|
+      # database cookbook LWRP to create a user in "remote" instance
       mysql_database_user "#{db_user}-#{hive_host}" do
         connection mysql_connection_info
         username db_user


### PR DESCRIPTION
This PR updates the underlying mysql cookbook dependencies, in order to support more recent versions and OSes.  Significantly, this cookbook used to rely on the mysql root password attribute set by the old mysql cookbook.  The new mysql cookbook no longer sets this attribute, and therefore the root credentials must now be provided to this cookbook.  For this reason, it is a major version bump.  For consistency, it reuses the same password attribute for now.